### PR TITLE
examples/external-traefik/traefik/docker-compose.yml: docker.sock should be mounted as readonly

### DIFF
--- a/examples/external-traefik/traefik/docker-compose.yml
+++ b/examples/external-traefik/traefik/docker-compose.yml
@@ -12,7 +12,7 @@ services:
         - 80:80
         - 8080:8080
     volumes:
-        - /var/run/docker.sock:/var/run/docker.sock
+        - /var/run/docker.sock:/var/run/docker.sock:ro
     networks:
         - traefik
 networks:


### PR DESCRIPTION
…ould be mounted as readonly